### PR TITLE
Add basic auth token persistence

### DIFF
--- a/cmd/hisame/main.go
+++ b/cmd/hisame/main.go
@@ -22,8 +22,12 @@ func main() {
 	}
 
 	state.InitialiseAppState(cfg)
-
 	logrus.Infof("App state initialised.  Log level: %s", logrus.GetLevel().String())
+
+	err = state.GetAppState().LoadAuthToken()
+	if err != nil {
+		logrus.Warnf("Failed to load token from disk: %v", err)
+	}
 
 	a := app.NewWithID("Hisame")
 	w := a.NewWindow("Hisame")

--- a/internal/state/app_state.go
+++ b/internal/state/app_state.go
@@ -1,16 +1,21 @@
 package state
 
 import (
+	"fmt"
 	"github.com/StarTerrarium/hisame/internal/config"
 	"github.com/StarTerrarium/hisame/internal/utils"
 	"github.com/sirupsen/logrus"
+	"os"
+	"path/filepath"
+	"runtime"
 	"sync"
 )
 
 type AppState struct {
 	mutex sync.RWMutex
 
-	config *config.UserConfig
+	config    *config.UserConfig
+	authToken string // TODO: Likely don't need to store this once the AniList client is created.
 }
 
 // Use a Singleton to manage the application state
@@ -52,4 +57,118 @@ func (s *AppState) GetConfig() *config.UserConfig {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 	return s.config
+}
+
+func getTokenFilePath() (string, error) {
+	var dir string
+
+	if runtime.GOOS == "windows" {
+		dir = os.Getenv("APPDATA")
+		if dir == "" {
+			return "", fmt.Errorf("APPDATA environment variable not set")
+		}
+		dir = filepath.Join(dir, "hisame")
+	} else if runtime.GOOS == "darwin" {
+		dir = filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "hisame")
+	} else {
+		dir = os.Getenv("XDG_DATA_HOME")
+		if dir == "" {
+			dir = filepath.Join(os.Getenv("HOME"), ".local", "share")
+		}
+		dir = filepath.Join(dir, "hisame")
+	}
+
+	tokenFilePath := filepath.Join(dir, "token")
+	return tokenFilePath, nil
+}
+
+// GetAuthToken gets the authentication token.
+func (s *AppState) GetAuthToken() string {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return s.authToken
+}
+
+// SetAuthToken sets the authentication token.
+func (s *AppState) SetAuthToken(token string) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.authToken = token
+}
+
+// LoadAuthToken loads the token from disk and sets it in AppState.
+func (s *AppState) LoadAuthToken() error {
+	tokenFilePath, err := getTokenFilePath()
+	if err != nil {
+		return err
+	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	data, err := os.ReadFile(tokenFilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			logrus.Info("No token file found; starting without authentication")
+			return nil
+		}
+		logrus.Errorf("Failed to read token file: %v", err)
+		return err
+	}
+
+	s.authToken = string(data)
+	logrus.Info("Authentication token loaded from disk")
+	return nil
+}
+
+// SaveAuthToken saves the current authentication token to disk.
+func (s *AppState) SaveAuthToken() error {
+	tokenFilePath, err := getTokenFilePath()
+	if err != nil {
+		return err
+	}
+
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	// Create the directory if it doesn't exist
+	err = os.MkdirAll(filepath.Dir(tokenFilePath), 0700)
+	if err != nil {
+		logrus.Errorf("Failed to create token directory: %v", err)
+		return err
+	}
+
+	// Write the token to the file
+	err = os.WriteFile(tokenFilePath, []byte(s.authToken), 0600)
+	if err != nil {
+		logrus.Errorf("Failed to write token file: %v", err)
+		return err
+	}
+
+	logrus.Info("Authentication token saved to disk")
+	return nil
+}
+
+// ClearAuthToken clears the token from AppState and deletes it from disk.
+func (s *AppState) ClearAuthToken() error {
+	tokenFilePath, err := getTokenFilePath()
+	if err != nil {
+		return err
+	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.authToken = ""
+
+	err = os.Remove(tokenFilePath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			logrus.Errorf("Failed to delete token file: %v", err)
+			return err
+		}
+	}
+
+	logrus.Info("Authentication token file deleted")
+	return nil
 }

--- a/internal/ui/login_page.go
+++ b/internal/ui/login_page.go
@@ -103,6 +103,6 @@ func (lp *LoginPage) startLoginFlow(authInstance *auth.Auth) {
 
 		loadingDialog.Hide()
 		logrus.Info("Login complete")
-		getScreenManager().HandleLoginSuccess()
+		getScreenManager().HandleLoginSuccess(token)
 	}()
 }

--- a/internal/ui/navigation_bar.go
+++ b/internal/ui/navigation_bar.go
@@ -51,13 +51,15 @@ func (nb *NavigationBar) buildContent() fyne.CanvasObject {
 	})
 	nb.logoutButton = widget.NewButton("Logout", func() {
 		logrus.Debug("Logout button clicked")
-		// Handle logout logic
+		getScreenManager().HandleLogout()
 	})
 
 	// Initially disable all buttons
-	buttonsToDisable := []*widget.Button{nb.animeButton, nb.mangaButton, nb.searchButton, nb.settingsButton, nb.logoutButton}
-	for _, btn := range buttonsToDisable {
-		btn.Disable()
+	if !getScreenManager().isAuth {
+		buttonsToDisable := []*widget.Button{nb.animeButton, nb.mangaButton, nb.searchButton, nb.settingsButton, nb.logoutButton}
+		for _, btn := range buttonsToDisable {
+			btn.Disable()
+		}
 	}
 
 	// Left and right containers


### PR DESCRIPTION
This commit adds a first pass at saving & loading the auth token.  It is likely to change when the AniList client is created as that is the only consumer of the token.  But for now this demonstrates the ability to save the token so the user does not need to login every time Hisame starts up.